### PR TITLE
Define Mandatory Status of the Typebox Object Definition

### DIFF
--- a/src/Json/json2typebox.spec.ts
+++ b/src/Json/json2typebox.spec.ts
@@ -86,7 +86,7 @@ describe("json2jsonSchema", () => {
       const type = "Unsigned Integer";
       const description =
         "The number of successive communication attempts before which a communication sequence is considered as failed.";
-      const isOptional = false;
+      const mandatoryStatus = "Mandatory";
       const rangeEnumeration = null;
       const id = "16";
       const units = "";
@@ -94,7 +94,7 @@ describe("json2jsonSchema", () => {
         name,
         type,
         description,
-        isOptional,
+        mandatoryStatus,
         rangeEnumeration,
         id,
         units
@@ -111,7 +111,7 @@ describe("json2jsonSchema", () => {
       const type = "Unsigned Integer";
       const description =
         "The number of successive communication attempts before which a communication sequence is considered as failed.";
-      const isOptional = false;
+      const mandatoryStatus = "Mandatory";
       const rangeEnumeration = [1, 65534];
       const minimum = 1;
       const maximum = 65534;
@@ -121,7 +121,7 @@ describe("json2jsonSchema", () => {
         name,
         type,
         description,
-        isOptional,
+        mandatoryStatus,
         rangeEnumeration,
         id,
         units
@@ -139,7 +139,7 @@ describe("json2jsonSchema", () => {
       const type = "Unsigned Integer";
       const description =
         "The number of successive communication attempts before which a communication sequence is considered as failed.";
-      const isOptional = false;
+      const mandatoryStatus = "Mandatory";
       const rangeEnumeration = null;
       const id = "16";
       const units = "s";
@@ -147,7 +147,7 @@ describe("json2jsonSchema", () => {
         name,
         type,
         description,
-        isOptional,
+        mandatoryStatus,
         rangeEnumeration,
         id,
         units
@@ -163,7 +163,7 @@ describe("json2jsonSchema", () => {
       const type = "Unsigned Integer";
       const description =
         "The number of successive communication attempts before which a communication sequence is considered as failed.";
-      const isOptional = true;
+      const mandatoryStatus = "Optional";
       const rangeEnumeration = null;
       const id = "16";
       const units = "";
@@ -171,7 +171,7 @@ describe("json2jsonSchema", () => {
         name,
         type,
         description,
-        isOptional,
+        mandatoryStatus,
         rangeEnumeration,
         id,
         units
@@ -186,7 +186,7 @@ describe("json2jsonSchema", () => {
       const type = "Unsigned Integer";
       const description =
         "The number of successive communication attempts before which a communication sequence is considered as failed.";
-      const isOptional = false;
+      const mandatoryStatus = "Mandatory";
       const rangeEnumeration = null;
       const id = "16";
       const units = "";
@@ -194,7 +194,7 @@ describe("json2jsonSchema", () => {
         name,
         type,
         description,
-        isOptional,
+        mandatoryStatus,
         rangeEnumeration,
         id,
         units

--- a/src/Json/json2typebox.spec.ts
+++ b/src/Json/json2typebox.spec.ts
@@ -18,7 +18,7 @@ describe("json2jsonSchema", () => {
         },
         {
           rangeEnumeration: [1, 65534],
-          isOptional: false,
+          mandatoryStatus: "Mandatory",
           type: "Integer",
           units: "s",
         },
@@ -32,7 +32,7 @@ describe("json2jsonSchema", () => {
         },
         {
           rangeEnumeration: [1, 655, 34],
-          isOptional: true,
+          mandatoryStatus: "Optional",
           type: "String",
           units: "",
         },
@@ -46,7 +46,7 @@ describe("json2jsonSchema", () => {
         },
         {
           rangeEnumeration: null,
-          isOptional: true,
+          mandatoryStatus: "Optional",
           type: "String",
           units: "",
         },
@@ -71,7 +71,7 @@ describe("json2jsonSchema", () => {
           name: "Short Server ID",
           type: expected.type,
           description: "Used as link to associate server Object Instance.",
-          isOptional: expected.isOptional,
+          mandatoryStatus: expected.mandatoryStatus,
           rangeEnumeration: expected.rangeEnumeration,
           id: "0",
           units: expected.units,

--- a/src/Json/json2typebox.spec.ts
+++ b/src/Json/json2typebox.spec.ts
@@ -180,6 +180,29 @@ describe("json2jsonSchema", () => {
 
       expect(typeboxDefinition).toBe(result);
     });
+
+    it("Should return a typebox definition in string specifying mandatory value", () => {
+      const name = "Communication Retry Count";
+      const type = "Unsigned Integer";
+      const description =
+        "The number of successive communication attempts before which a communication sequence is considered as failed.";
+      const isOptional = false;
+      const rangeEnumeration = null;
+      const id = "16";
+      const units = "";
+      const typeboxDefinition = getTypebox(
+        name,
+        type,
+        description,
+        isOptional,
+        rangeEnumeration,
+        id,
+        units
+      );
+      const result = `_16: Type.Number({title: 'Communication Retry Count', description: "The number of successive communication attempts before which a communication sequence is considered as failed."})`;
+
+      expect(typeboxDefinition).toBe(result);
+    });
   });
 
   describe("getObjectProps", () => {

--- a/src/Json/json2typebox.spec.ts
+++ b/src/Json/json2typebox.spec.ts
@@ -4,6 +4,7 @@ import {
   parseData,
   getRangeEnumeration,
   defineInstaceType,
+  defineMandatoryStatus,
 } from "./json2typebox";
 
 describe("json2jsonSchema", () => {
@@ -264,6 +265,32 @@ describe("json2jsonSchema", () => {
       const value = "";
       expect(() => defineInstaceType(instanceType, value)).toThrow(
         `Instance type is not allowed`
+      );
+    });
+  });
+
+  describe("defineMandatoryStatus", () => {
+    it("Should create a mandatory instance type definition", () => {
+      const instanceType = "Mandatory";
+      const value = "";
+      expect(defineMandatoryStatus(instanceType, value)).toStrictEqual(
+        `${value}`
+      );
+    });
+
+    it("Should create an optional instance type definition", () => {
+      const instanceType = "Optional";
+      const value = "";
+      expect(defineMandatoryStatus(instanceType, value)).toStrictEqual(
+        `Type.Optional(${value})`
+      );
+    });
+
+    it("Should return error when instance type is different than allowed options", () => {
+      const instanceType = "somethingElse";
+      const value = "";
+      expect(() => defineMandatoryStatus(instanceType, value)).toThrow(
+        `Status specification is not allowed`
       );
     });
   });

--- a/src/Json/json2typebox.ts
+++ b/src/Json/json2typebox.ts
@@ -178,6 +178,7 @@ export const defineInstaceType = (
     : `Type.Object({${value}})`;
 };
 
+// TODO: add test case
 /**
  * Generates the typescript code of the typebox object definition
  */

--- a/src/Json/json2typebox.ts
+++ b/src/Json/json2typebox.ts
@@ -101,7 +101,7 @@ export const parseData = (
   name: string;
   type: string;
   description: string;
-  isOptional: boolean;
+  mandatoryStatus: string;
   rangeEnumeration: [...(number | null)[]] | null;
   id: string;
   units: string;
@@ -109,11 +109,19 @@ export const parseData = (
   const name = element.Name[0];
   const type = element.Type[0];
   const description = dataCleaning(element.Description[0]);
-  const isOptional = element.Mandatory[0] === "Optional";
+  const mandatoryStatus = element.Mandatory[0];
   const rangeEnumeration = getRangeEnumeration(element.RangeEnumeration[0]);
   const id = element.ATTR.ID;
   const units = element.Units[0];
-  return { name, type, description, isOptional, rangeEnumeration, id, units };
+  return {
+    name,
+    type,
+    description,
+    mandatoryStatus,
+    rangeEnumeration,
+    id,
+    units,
+  };
 };
 
 /**

--- a/src/Json/json2typebox.ts
+++ b/src/Json/json2typebox.ts
@@ -203,10 +203,7 @@ export const createDefinition = (Lwm2mRegistry: any): string => {
     Lwm2mRegistry.MultipleInstances[0],
     objectData
   );
-  const object = `_${id}: ${defineMandatoryStatus(
-    mandatoryStatus,
-    typeDefinition
-  )}`;
+  const object = `${defineMandatoryStatus(mandatoryStatus, typeDefinition)}`;
 
   const typeboxDefinition = `export const _${id} = ${object}`; // FIXME:  { additionalProperties: false },  --> is creating issues. Error message: Expected 1-2 arguments, but got 3.
 

--- a/src/Json/json2typebox.ts
+++ b/src/Json/json2typebox.ts
@@ -10,7 +10,7 @@ import { keyCleaning } from "./../utils/keyCleaning";
  * @param name
  * @param type
  * @param description
- * @param isOptional
+ * @param mandatoryStatus
  * @param rangeEnumeration
  * @param id
  * @param units
@@ -20,7 +20,7 @@ export const getTypebox = (
   name: string,
   type: string,
   description: string,
-  isOptional: boolean,
+  mandatoryStatus: string,
   rangeEnumeration: [...(number | null)[]] | null,
   id: string,
   units: string
@@ -135,7 +135,7 @@ export const getObjectProps = (items: any[]) =>
         element.name,
         element.type,
         element.description,
-        element.isOptional,
+        element.mandatoryStatus,
         element.rangeEnumeration,
         element.id,
         element.units


### PR DESCRIPTION
Create a new method to determinate if the object is mandatory or optional and return the type box definition with the custom implementation.

The validation is very concise, however a new method was created because it is considered a essential part on the process and it is valuable to have tests that assurance correct functionality of that section. Which is easier by having that code in a single method. 

Some side changes were made in order to implement this as for example the rename of a variable, from a boolean 'isOptional' to a string 'mandatoryStatus'.

Issue Link: https://github.com/MLopezJ/LWM2M-JSONSchema/issues/13 