### PR TITLE
feat: Update RangeEnumeration definition

### DIFF
--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -263,15 +263,15 @@ describe("createResourceDefinition", () => {
   it.each([
     [
       "0..255 bytes",
-      `_16: Type.Number({title: 'name', description: "Description ... 0..255 bytes"})`,
+      `_16: Type.Number({title: 'name', description: "Description. RangeEnumeration is not following the defined standard by openmobilealliance.org and for that reason value is not contemplate in the type definition. Original RangeEnumeration value: '0..255 bytes'"})`,
     ],
     [
       "1: normal\r\n\t\t\t\t2: remote\r\n\t\t\t\t3: local",
-      `_16: Type.Number({title: 'name', description: "Description ... 1: normal      2: remote      3: local"})`,
+      `_16: Type.Number({title: 'name', description: "Description. RangeEnumeration is not following the defined standard by openmobilealliance.org and for that reason value is not contemplate in the type definition. Original RangeEnumeration value: '1: normal      2: remote      3: local'"})`,
     ],
     [
       "<7 to >12.5",
-      `_16: Type.Number({title: 'name', description: "Description ... <7 to >12.5"})`,
+      `_16: Type.Number({title: 'name', description: "Description. RangeEnumeration is not following the defined standard by openmobilealliance.org and for that reason value is not contemplate in the type definition. Original RangeEnumeration value: '<7 to >12.5'"})`,
     ],
   ])(
     "Should check typebox definition when rangeEnumeration format is invalid",

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -1,6 +1,7 @@
 import {
   createResourceDefinition,
   createLiteralDefinition,
+  createEnumDefinition,
 } from "./createResourceDefinition";
 
 describe("createResourceDefinition", () => {
@@ -196,5 +197,18 @@ describe("createLiteralDefinition", () => {
     expect(
       createLiteralDefinition(params.isString, params.value, params.props)
     ).toBe(expected);
+  });
+});
+
+describe("createEnumDefinition", () => {
+  it.each([
+    [{ value: "a", props: "" }, `Type.Literal('a', {})`],
+    [{ value: 1, props: "" }, `Type.Literal(1, {})`],
+    [
+      { value: [1, 2, 3], props: "" },
+      `Type.Union([Type.Literal(1, {}),Type.Literal(2, {}),Type.Literal(3, {})],{})`,
+    ], // Type.Literal(1)
+  ])("Should create a 'Enum' typebox definition", (params, expected) => {
+    expect(createEnumDefinition(params.value, params.props)).toBe(expected);
   });
 });

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -187,6 +187,30 @@ describe("createResourceDefinition", () => {
 
     expect(typeboxDefinition).toBe(result);
   });
+
+  it("Should check typebox definition when rangeEnumeration format is invalid", () => {
+    const name = "name";
+    const type = "Integer";
+    const description = "Description";
+    const mandatoryStatus = "Mandatory";
+    const multipleInstances = "Single";
+    const rangeEnumeration = "0..255 bytes";
+    const id = "16";
+    const units = "";
+    const typeboxDefinition = createResourceDefinition(
+      name,
+      type,
+      description,
+      mandatoryStatus,
+      multipleInstances,
+      rangeEnumeration,
+      id,
+      units
+    );
+    const result = `_16: Type.Number({title: 'name', description: "Description ... 0..255 bytes"})`;
+
+    expect(typeboxDefinition).toBe(result);
+  });
 });
 
 describe("createLiteralDefinition", () => {

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -188,30 +188,6 @@ describe("createResourceDefinition", () => {
     expect(typeboxDefinition).toBe(result);
   });
 
-  it("Should check typebox definition when rangeEnumeration format is invalid", () => {
-    const name = "name";
-    const type = "Integer";
-    const description = "Description";
-    const mandatoryStatus = "Mandatory";
-    const multipleInstances = "Single";
-    const rangeEnumeration = "0..255 bytes";
-    const id = "16";
-    const units = "";
-    const typeboxDefinition = createResourceDefinition(
-      name,
-      type,
-      description,
-      mandatoryStatus,
-      multipleInstances,
-      rangeEnumeration,
-      id,
-      units
-    );
-    const result = `_16: Type.Number({title: 'name', description: "Description ... 0..255 bytes"})`;
-
-    expect(typeboxDefinition).toBe(result);
-  });
-
   it("Should check typebox definition when rangeEnumeration format is a range", () => {
     const name = "name";
     const type = "Integer";
@@ -283,6 +259,44 @@ describe("createResourceDefinition", () => {
 
     expect(typeboxDefinition).toBe(result);
   });
+
+  it.each([
+    [
+      "0..255 bytes",
+      `_16: Type.Number({title: 'name', description: "Description ... 0..255 bytes"})`,
+    ],
+    [
+      "1: normal\r\n\t\t\t\t2: remote\r\n\t\t\t\t3: local",
+      `_16: Type.Number({title: 'name', description: "Description ... 1: normal      2: remote      3: local"})`,
+    ],
+    [
+      "<7 to >12.5",
+      `_16: Type.Number({title: 'name', description: "Description ... <7 to >12.5"})`,
+    ],
+  ])(
+    "Should check typebox definition when rangeEnumeration format is invalid",
+    (rangeEnumeration, expected) => {
+      const name = "name";
+      const type = "Integer";
+      const description = "Description";
+      const mandatoryStatus = "Mandatory";
+      const multipleInstances = "Single";
+      const id = "16";
+      const units = "";
+      const typeboxDefinition = createResourceDefinition(
+        name,
+        type,
+        description,
+        mandatoryStatus,
+        multipleInstances,
+        rangeEnumeration,
+        id,
+        units
+      );
+
+      expect(typeboxDefinition).toBe(expected);
+    }
+  );
 });
 
 describe("createLiteralDefinition", () => {

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -8,7 +8,7 @@ describe("createResourceDefinition", () => {
       "The number of successive communication attempts before which a communication sequence is considered as failed.";
     const mandatoryStatus = "Mandatory";
     const multipleInstances = "Single";
-    const rangeEnumeration = null;
+    const rangeEnumeration = "";
     const id = "16";
     const units = "";
     const typeboxDefinition = createResourceDefinition(
@@ -35,7 +35,7 @@ describe("createResourceDefinition", () => {
       "The number of successive communication attempts before which a communication sequence is considered as failed.";
     const mandatoryStatus = "Mandatory";
     const multipleInstances = "Single";
-    const rangeEnumeration = [1, 65534];
+    const rangeEnumeration = "1..65534";
     const minimum = 1;
     const maximum = 65534;
     const id = "16";
@@ -65,7 +65,7 @@ describe("createResourceDefinition", () => {
       "The number of successive communication attempts before which a communication sequence is considered as failed.";
     const mandatoryStatus = "Mandatory";
     const multipleInstances = "Single";
-    const rangeEnumeration = null;
+    const rangeEnumeration = "";
     const id = "16";
     const units = "s";
     const typeboxDefinition = createResourceDefinition(
@@ -91,7 +91,7 @@ describe("createResourceDefinition", () => {
       "The number of successive communication attempts before which a communication sequence is considered as failed.";
     const mandatoryStatus = "Optional";
     const multipleInstances = "Single";
-    const rangeEnumeration = null;
+    const rangeEnumeration = "";
     const id = "16";
     const units = "";
     const typeboxDefinition = createResourceDefinition(
@@ -116,7 +116,7 @@ describe("createResourceDefinition", () => {
       "The number of successive communication attempts before which a communication sequence is considered as failed.";
     const mandatoryStatus = "Mandatory";
     const multipleInstances = "Single";
-    const rangeEnumeration = null;
+    const rangeEnumeration = "";
     const id = "16";
     const units = "";
     const typeboxDefinition = createResourceDefinition(
@@ -141,7 +141,7 @@ describe("createResourceDefinition", () => {
       "The number of successive communication attempts before which a communication sequence is considered as failed.";
     const mandatoryStatus = "Mandatory";
     const multipleInstances = "Multiple";
-    const rangeEnumeration = null;
+    const rangeEnumeration = "";
     const id = "16";
     const units = "";
     const typeboxDefinition = createResourceDefinition(
@@ -166,7 +166,7 @@ describe("createResourceDefinition", () => {
       "The number of successive communication attempts before which a communication sequence is considered as failed.";
     const mandatoryStatus = "Mandatory";
     const multipleInstances = "Single";
-    const rangeEnumeration = null;
+    const rangeEnumeration = "";
     const id = "16";
     const units = "";
     const typeboxDefinition = createResourceDefinition(

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -211,6 +211,30 @@ describe("createResourceDefinition", () => {
 
     expect(typeboxDefinition).toBe(result);
   });
+
+  it("Should check typebox definition when rangeEnumeration format is a range", () => {
+    const name = "name";
+    const type = "Integer";
+    const description = "Description";
+    const mandatoryStatus = "Mandatory";
+    const multipleInstances = "Single";
+    const rangeEnumeration = "0..255";
+    const id = "16";
+    const units = "";
+    const typeboxDefinition = createResourceDefinition(
+      name,
+      type,
+      description,
+      mandatoryStatus,
+      multipleInstances,
+      rangeEnumeration,
+      id,
+      units
+    );
+    const result = `_16: Type.Number({title: 'name', description: "Description", minimum: 0, maximum: 255})`;
+
+    expect(typeboxDefinition).toBe(result);
+  });
 });
 
 describe("createLiteralDefinition", () => {

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -259,6 +259,30 @@ describe("createResourceDefinition", () => {
 
     expect(typeboxDefinition).toBe(result);
   });
+
+  it("Should check typebox definition when rangeEnumeration format is a list", () => {
+    const name = "name";
+    const type = "Integer";
+    const description = "Description";
+    const mandatoryStatus = "Mandatory";
+    const multipleInstances = "Single";
+    const rangeEnumeration = "0, 1, 2";
+    const id = "16";
+    const units = "";
+    const typeboxDefinition = createResourceDefinition(
+      name,
+      type,
+      description,
+      mandatoryStatus,
+      multipleInstances,
+      rangeEnumeration,
+      id,
+      units
+    );
+    const result = `_16: Type.Union([Type.Literal(0 ),Type.Literal(1 ),Type.Literal(2 )],{title: 'name', description: "Description"})`;
+
+    expect(typeboxDefinition).toBe(result);
+  });
 });
 
 describe("createLiteralDefinition", () => {

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -1,4 +1,7 @@
-import { createResourceDefinition } from "./createResourceDefinition";
+import {
+  createResourceDefinition,
+  createLiteralDefinition,
+} from "./createResourceDefinition";
 
 describe("createResourceDefinition", () => {
   it("Should return a typebox definition in string", () => {
@@ -182,5 +185,16 @@ describe("createResourceDefinition", () => {
     const result = `_16: Type.Number({title: 'Communication Retry Count', description: "The number of successive communication attempts before which a communication sequence is considered as failed."})`;
 
     expect(typeboxDefinition).toBe(result);
+  });
+});
+
+describe("createLiteralDefinition", () => {
+  it.each([
+    [{ isString: true, value: "a", props: "" }, `Type.Literal('a', {})`],
+    [{ isString: false, value: 1, props: "" }, `Type.Literal(1, {})`],
+  ])("Should create a 'Literal' typebox definition", (params, expected) => {
+    expect(
+      createLiteralDefinition(params.isString, params.value, params.props)
+    ).toBe(expected);
   });
 });

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -191,23 +191,38 @@ describe("createResourceDefinition", () => {
 
 describe("createLiteralDefinition", () => {
   it.each([
-    [{ isString: true, value: "a", props: "" }, `Type.Literal('a', {})`],
-    [{ isString: false, value: 1, props: "" }, `Type.Literal(1, {})`],
+    [
+      { isString: true, isUnion: false, value: "a", props: "" },
+      `Type.Literal('a' ,{})`,
+    ],
+    [
+      { isString: false, isUnion: false, value: 1, props: "" },
+      `Type.Literal(1 ,{})`,
+    ],
   ])("Should create a 'Literal' typebox definition", (params, expected) => {
     expect(
-      createLiteralDefinition(params.isString, params.value, params.props)
+      createLiteralDefinition(
+        params.isString,
+        params.isUnion,
+        params.value,
+        params.props
+      )
     ).toBe(expected);
   });
 });
 
 describe("createEnumDefinition", () => {
   it.each([
-    [{ value: "a", props: "" }, `Type.Literal('a', {})`],
-    [{ value: 1, props: "" }, `Type.Literal(1, {})`],
+    [{ value: "a", props: "" }, `Type.Literal('a' ,{})`],
+    [{ value: 1, props: "" }, `Type.Literal(1 ,{})`],
     [
       { value: [1, 2, 3], props: "" },
-      `Type.Union([Type.Literal(1, {}),Type.Literal(2, {}),Type.Literal(3, {})],{})`,
-    ], // Type.Literal(1)
+      `Type.Union([Type.Literal(1 ),Type.Literal(2 ),Type.Literal(3 )],{})`,
+    ],
+    [
+      { value: ["a", "b", "c"], props: "" },
+      `Type.Union([Type.Literal('a' ),Type.Literal('b' ),Type.Literal('c' )],{})`,
+    ],
   ])("Should create a 'Enum' typebox definition", (params, expected) => {
     expect(createEnumDefinition(params.value, params.props)).toBe(expected);
   });

--- a/src/Json/createResourceDefinition.spec.ts
+++ b/src/Json/createResourceDefinition.spec.ts
@@ -235,6 +235,30 @@ describe("createResourceDefinition", () => {
 
     expect(typeboxDefinition).toBe(result);
   });
+
+  it("Should check typebox definition when rangeEnumeration format is a single instance", () => {
+    const name = "name";
+    const type = "Integer";
+    const description = "Description";
+    const mandatoryStatus = "Mandatory";
+    const multipleInstances = "Single";
+    const rangeEnumeration = "0";
+    const id = "16";
+    const units = "";
+    const typeboxDefinition = createResourceDefinition(
+      name,
+      type,
+      description,
+      mandatoryStatus,
+      multipleInstances,
+      rangeEnumeration,
+      id,
+      units
+    );
+    const result = `_16: Type.Literal(0 ,{title: 'name', description: "Description"})`;
+
+    expect(typeboxDefinition).toBe(result);
+  });
 });
 
 describe("createLiteralDefinition", () => {

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -30,7 +30,6 @@ export const createResourceDefinition = (
 ): string => {
   let minimum = undefined;
   let maximum = undefined;
-  let enumeration = undefined;
 
   const rangeEnumObject: {
     invalidFormat: boolean;
@@ -53,7 +52,6 @@ export const createResourceDefinition = (
     `description: "${desc}"`,
     minimum !== undefined ? `minimum: ${minimum}` : undefined,
     maximum !== undefined ? `maximum: ${maximum}` : undefined,
-    enumeration !== undefined ? `enumeration: [${enumeration}]` : undefined,
     units ? `units: '${cleanUnits(units)}'` : undefined,
   ].reduce((previous, current, index) => {
     if (current) {

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -44,8 +44,13 @@ export const createResourceDefinition = (
   // 4- if range enumeration is valid and type is enum and is list, check type of every item and create definition
 
   let descriptionValue = `${dataCleaning(description)}`;
-  if (rangeEnumObject.invalidFormat === true) {
-    descriptionValue = `${descriptionValue} ... ${rangeEnumObject.value}`; // TODO: improve description
+  if (
+    rangeEnumObject.invalidFormat === true &&
+    rangeEnumObject.value !== "null"
+  ) {
+    descriptionValue = `${descriptionValue} ... ${dataCleaning(
+      rangeEnumObject.value as any
+    )}`; // TODO: improve description
   }
 
   let minimum = undefined;

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -89,7 +89,10 @@ export const createResourceDefinition = (
  * @param props
  * @returns
  */
-const createEnumDefinition = (value: string | number | [], props: string) => {
+export const createEnumDefinition = (
+  value: string | number | number[] | string[],
+  props: string
+) => {
   if (typeof value === "number" || typeof value === "string") {
     const isString = isNaN(+(value as any));
     return createLiteralDefinition(isString, value, props);
@@ -97,7 +100,7 @@ const createEnumDefinition = (value: string | number | [], props: string) => {
     // list case
     return `Type.Union([${(value as any).map((element: string | number) => {
       return createLiteralDefinition(isNaN(+element), element, props);
-    })}],{${props}} )`;
+    })}],{${props}})`;
   }
 };
 

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -34,15 +34,6 @@ export const createResourceDefinition = (
     dataStruct?: "enum" | "range" | undefined;
   } = getRangeEnumeration(rangeEnumeration);
 
-  // rules:
-  // 1- if range enumeration is invalid format, the description should contain the value of range enumeration
-
-  // 2- if range enumeration si valid and is range type, add max and min to props
-
-  // 3- if range enumeration is valid and type is enum and single isntance, check if is string and generate literal based on that
-
-  // 4- if range enumeration is valid and type is enum and is list, check type of every item and create definition
-
   let descriptionValue = `${dataCleaning(description)}`;
   if (
     rangeEnumObject.invalidFormat === true &&
@@ -76,10 +67,9 @@ export const createResourceDefinition = (
 
   let object = `Type.${getType(type)}({${props}})`;
   if (rangeEnumObject.dataStruct === "enum") {
-    object = createEnumDefinition(rangeEnumObject.value as any, props as any); // TODO: fix this
+    object = createEnumDefinition(rangeEnumObject.value as any, props as any);
   }
 
-  //let object = `Type.${getType(type)}({${props}})`;
   object = getMultipleInstanceStatus(multipleInstances, object);
   object = getMandatoryStatus(mandatoryStatus, object);
 

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -5,6 +5,7 @@ import { getMin } from "../utils/getMin";
 import { getType } from "../utils/getType";
 import { getMandatoryStatus } from "./getMandatoryStatus";
 import { getMultipleInstanceStatus } from "./getMultipleInstanceStatus";
+import { getRangeEnumeration } from "./getRangeEnumeration";
 
 /**
  * Generate typebox definition with received params
@@ -23,7 +24,7 @@ export const createResourceDefinition = (
   description: string,
   mandatoryStatus: string,
   multipleInstances: string,
-  rangeEnumeration: [...(number | null)[]] | null,
+  rangeEnumeration: string,
   id: string,
   units: string
 ): string => {
@@ -31,13 +32,19 @@ export const createResourceDefinition = (
   let maximum = undefined;
   let enumeration = undefined;
 
-  if (rangeEnumeration !== null) {
-    minimum = rangeEnumeration[0];
-    maximum = rangeEnumeration[1];
-    if (rangeEnumeration.length > 2) {
-      minimum = getMin(rangeEnumeration);
-      maximum = getMax(rangeEnumeration);
-      enumeration = rangeEnumeration;
+  const rangeEnumObject: {
+    invalidFormat: boolean;
+    value: string | Number | Number[] | String[] | null;
+    dataStruct?: "enum" | "range" | undefined;
+  } = getRangeEnumeration(rangeEnumeration);
+
+  let desc = `"${dataCleaning(description)}`;
+  if (rangeEnumObject.invalidFormat === true) {
+    desc = `"${desc} ... "${rangeEnumObject.value}"`;
+  } else {
+    if (rangeEnumObject.dataStruct === "range") {
+      minimum = (rangeEnumObject.value as any)[0];
+      maximum = (rangeEnumObject.value as any)[1];
     }
   }
 

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -108,11 +108,11 @@ const createEnumDefinition = (value: string | number | [], props: string) => {
  * @param props
  * @returns
  */
-const createLiteralDefinition = (
+export const createLiteralDefinition = (
   isString: boolean,
   value: string | number,
   props: string
 ): string =>
   isString
-    ? `Type.Literal('${value}, {${props}}')`
+    ? `Type.Literal('${value}', {${props}})`
     : `Type.Literal(${value}, {${props}})`;

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -63,6 +63,8 @@ export const createResourceDefinition = (
     return previous;
   }, "");
 
+  // TODO: improve code
+  // TODO: add test cases
   let object = `Type.${getType(type)}({${props}})`;
   if (rangeEnumObject.dataStruct === "enum") {
     if (

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -89,7 +89,7 @@ export const createResourceDefinition = (
 };
 
 /**
- *
+ * Create an enumeration definition from a single instance or a list of values
  * @param value
  * @param props
  * @returns

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -1,7 +1,5 @@
 import { cleanUnits } from "../utils/cleanUnits";
 import { dataCleaning } from "../utils/dataCleaning";
-import { getMax } from "../utils/getMax";
-import { getMin } from "../utils/getMin";
 import { getType } from "../utils/getType";
 import { getMandatoryStatus } from "./getMandatoryStatus";
 import { getMultipleInstanceStatus } from "./getMultipleInstanceStatus";

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -74,8 +74,6 @@ export const createResourceDefinition = (
     return previous;
   }, "");
 
-  // TODO: improve code
-  // TODO: add test cases
   let object = `Type.${getType(type)}({${props}})`;
   if (rangeEnumObject.dataStruct === "enum") {
     object = createEnumDefinition(rangeEnumObject.value as any, props as any); // TODO: fix this

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -95,11 +95,11 @@ export const createEnumDefinition = (
 ) => {
   if (typeof value === "number" || typeof value === "string") {
     const isString = isNaN(+(value as any));
-    return createLiteralDefinition(isString, value, props);
+    return createLiteralDefinition(isString, false, value, props);
   } else {
     // list case
     return `Type.Union([${(value as any).map((element: string | number) => {
-      return createLiteralDefinition(isNaN(+element), element, props);
+      return createLiteralDefinition(isNaN(+element), true, element, props);
     })}],{${props}})`;
   }
 };
@@ -107,15 +107,17 @@ export const createEnumDefinition = (
 /**
  * Create custom "literal" type definition
  * @param isString
+ * @param isUnion
  * @param value
  * @param props
  * @returns
  */
 export const createLiteralDefinition = (
   isString: boolean,
+  isUnion: boolean,
   value: string | number,
   props: string
 ): string =>
   isString
-    ? `Type.Literal('${value}', {${props}})`
-    : `Type.Literal(${value}, {${props}})`;
+    ? `Type.Literal('${value}' ${isUnion ? "" : `,{${props}}`})`
+    : `Type.Literal(${value} ${isUnion ? "" : `,{${props}}`})`;

--- a/src/Json/createResourceDefinition.ts
+++ b/src/Json/createResourceDefinition.ts
@@ -48,9 +48,9 @@ export const createResourceDefinition = (
     rangeEnumObject.invalidFormat === true &&
     rangeEnumObject.value !== "null"
   ) {
-    descriptionValue = `${descriptionValue} ... ${dataCleaning(
+    descriptionValue = `${descriptionValue}. RangeEnumeration is not following the defined standard by openmobilealliance.org and for that reason value is not contemplate in the type definition. Original RangeEnumeration value: '${dataCleaning(
       rangeEnumObject.value as any
-    )}`; // TODO: improve description
+    )}'`;
   }
 
   let minimum = undefined;

--- a/src/Json/getRangeEnumeration.spec.ts
+++ b/src/Json/getRangeEnumeration.spec.ts
@@ -8,18 +8,6 @@ import {
 
 describe("isInvalidFormat", () => {
   it.only.each([
-    ["", false],
-    ["\r\n        ", false],
-    ["\r\n        \r\n ", false],
-    ["ValidCase", false],
-    ["\r\n    0..255    \r\n ", false],
-    ["\r\n    1,2,3    \r\n ", false],
-    ["\r\n    1    \r\n ", false],
-    ["0", false],
-    ["value", false],
-    ["0..125", false],
-    ["1..256", false],
-    ["16,32,48", false],
     ["0..255 bytes", true],
     ["1..64 Bytes", true],
     ["0..255 Gigabyte", true],
@@ -32,7 +20,24 @@ describe("isInvalidFormat", () => {
     ["8-Bits", true],
     ["2 Instances", true],
     ["1: normal\r\n\t\t\t\t2: remote\r\n\t\t\t\t3: local", true],
-  ])("Should check if format is invalid: %p -> %p", (value, expected) =>
+  ])("Should check invalid format: %p", (value, expected) =>
+    expect(isInvalidFormat(value)).toStrictEqual(expected)
+  );
+
+  it.only.each([
+    ["", false],
+    ["\r\n        ", false],
+    ["\r\n        \r\n ", false],
+    ["ValidCase", false],
+    ["\r\n    0..255    \r\n ", false],
+    ["\r\n    1,2,3    \r\n ", false],
+    ["\r\n    1    \r\n ", false],
+    ["0", false],
+    ["value", false],
+    ["0..125", false],
+    ["1..256", false],
+    ["16,32,48", false],
+  ])("Should check valid format: %p", (value, expected) =>
     expect(isInvalidFormat(value)).toStrictEqual(expected)
   );
 });

--- a/src/Json/getRangeEnumeration.spec.ts
+++ b/src/Json/getRangeEnumeration.spec.ts
@@ -7,24 +7,22 @@ import {
 } from "./getRangeEnumeration";
 
 describe("isInvalidFormat", () => {
-  it.only.each([
+  it.each([
     ["0..255 bytes", true],
     ["1..64 Bytes", true],
     ["0..255 Gigabyte", true],
     ["no valid case", true],
     ["\r\n    0..255 bytes    \r\n ", true],
     ["AVAILABLE; UNAVAILABLE", true],
-    ["0..2^28-1", true],
     ["0; 3.8..20.5", true],
     ["<7 to >12.5", true],
-    ["8-Bits", true],
     ["2 Instances", true],
     ["1: normal\r\n\t\t\t\t2: remote\r\n\t\t\t\t3: local", true],
   ])("Should check invalid format: %p", (value, expected) =>
     expect(isInvalidFormat(value)).toStrictEqual(expected)
   );
 
-  it.only.each([
+  it.each([
     ["", false],
     ["\r\n        ", false],
     ["\r\n        \r\n ", false],
@@ -37,6 +35,8 @@ describe("isInvalidFormat", () => {
     ["0..125", false],
     ["1..256", false],
     ["16,32,48", false],
+    ["0..2^28-1", false],
+    ["8-Bits", false],
   ])("Should check valid format: %p", (value, expected) =>
     expect(isInvalidFormat(value)).toStrictEqual(expected)
   );

--- a/src/Json/getRangeEnumeration.spec.ts
+++ b/src/Json/getRangeEnumeration.spec.ts
@@ -1,4 +1,10 @@
-import { getRangeEnumeration, isInvalidFormat } from "./getRangeEnumeration";
+import {
+  getRangeEnumeration,
+  isInvalidFormat,
+  isRangeFormat,
+  isSingleEnum,
+  isListEnum,
+} from "./getRangeEnumeration";
 
 describe("isInvalidFormat", () => {
   it.each([
@@ -21,6 +27,50 @@ describe("isInvalidFormat", () => {
     ["ValidCase", false],
   ])("Should check if format is invalid: %p -> %p", (value, expected) =>
     expect(isInvalidFormat(value)).toStrictEqual(expected)
+  );
+});
+
+describe("isRangeFormat", () => {
+  it.each([
+    ["..", false],
+    ["1..", false],
+    ["..2", false],
+    ["0..2", true],
+    ["-10..-2", true],
+    ["0..2..10", false],
+    ["1", false],
+    ["1,2,3,4", false],
+  ])("Should check if range format is followed: %p -> %p", (value, expected) =>
+    expect(isRangeFormat(value)).toStrictEqual(expected)
+  );
+});
+
+describe("isSingleEnum", () => {
+  it.each([
+    ["1", true],
+    ["1     ", true],
+    ["\n1", true],
+    ["\n\t1", true],
+    ["\n\t1\n\t", true],
+    ["1,2,3,4", false],
+    ["0..2", false],
+    ["-10..-2", false],
+  ])(
+    "Should check if single enum format is followed: %p -> %p",
+    (value, expected) => expect(isSingleEnum(value)).toStrictEqual(expected)
+  );
+});
+
+describe("isListEnum", () => {
+  it.each([
+    ["1,2,3,4", true],
+    ["-1,2,-3,4", true],
+    ["1.2.3.4", false],
+    ["0..2", false],
+    ["1", false],
+  ])(
+    "Should check if list enum format is followed: %p -> %p",
+    (value, expected) => expect(isListEnum(value)).toStrictEqual(expected)
   );
 });
 

--- a/src/Json/getRangeEnumeration.spec.ts
+++ b/src/Json/getRangeEnumeration.spec.ts
@@ -1,17 +1,67 @@
-import { getRangeEnumeration } from "./getRangeEnumeration";
+import { getRangeEnumeration, isInvalidFormat } from "./getRangeEnumeration";
+
+describe("isInvalidFormat", () => {
+  it.each([
+    ["", false],
+    ["\r\n        ", false],
+    ["\r\n        \r\n ", false],
+    ["\r\n    0..255 bytes    \r\n ", true],
+    ["\r\n    0..255    \r\n ", false],
+    ["\r\n    1,2,3    \r\n ", false],
+    ["\r\n    1    \r\n ", false],
+    ["0", false],
+    ["value", false],
+    ["0..125", false],
+    ["1..256", false],
+    ["16,32,48", false],
+    ["0..255 bytes", true],
+    ["1..64 Bytes", true],
+    ["0..255 Gigabyte", true],
+    ["no valid case", true],
+    ["ValidCase", false],
+  ])("Should check if format is invalid: %p -> %p", (value, expected) =>
+    expect(isInvalidFormat(value)).toStrictEqual(expected)
+  );
+});
 
 describe("getRangeEnumeration", () => {
   it.each([
-    ["", null],
-    ["0..125", [0, 125]],
-    ["1..256", [1, 256]],
-    ["16,32,48", [16, 32, 48]],
-    ["0..255 bytes", [0, 255]],
-    ["1..64 Bytes", [1, 64]],
-    ["0..255 Gigabyte", [0, 255]],
-    ["no valid case", null],
-    ["noValidCase", null],
-  ])("Should return range enumeration: %s -> %p", (value, expected) =>
+    ["", { invalidFormat: false, value: null }],
+    ["\r\n        ", { invalidFormat: false, value: null }],
+    ["\r\n        \r\n ", { invalidFormat: false, value: null }],
+    [
+      "\r\n    0..255 bytes    \r\n ",
+      { invalidFormat: true, value: "\r\n    0..255 bytes    \r\n " },
+    ],
+    [
+      "\r\n    0..255    \r\n ",
+      { invalidFormat: false, value: [0, 255], dataStruct: "range" },
+    ],
+    [
+      "\r\n    1,2,3    \r\n ",
+      { invalidFormat: false, value: [1, 2, 3], dataStruct: "enum" },
+    ],
+    [
+      "\r\n    1    \r\n ",
+      { invalidFormat: false, value: 1, dataStruct: "enum" },
+    ],
+    ["0", { invalidFormat: false, value: 0, dataStruct: "enum" }],
+    ["value", { invalidFormat: false, value: "value", dataStruct: "enum" }],
+    ["0..125", { invalidFormat: false, value: [0, 125], dataStruct: "range" }],
+    ["1..256", { invalidFormat: false, value: [1, 256], dataStruct: "range" }],
+    [
+      "16,32,48",
+      { invalidFormat: false, value: [16, 32, 48], dataStruct: "enum" },
+    ],
+    ["0..255 bytes", { invalidFormat: true, value: "0..255 bytes" }],
+    ["1..64 Bytes", { invalidFormat: true, value: "1..64 Bytes" }],
+    ["0..255 Gigabyte", { invalidFormat: true, value: "0..255 Gigabyte" }],
+    ["no valid case", { invalidFormat: true, value: "no valid case" }],
+    [
+      "ValidCase",
+      { invalidFormat: false, value: "ValidCase", dataStruct: "enum" },
+    ],
+  ])("Should return range enumeration object: %p -> %p", (value, expected) =>
     expect(getRangeEnumeration(value)).toStrictEqual(expected)
   );
 });

--- a/src/Json/getRangeEnumeration.spec.ts
+++ b/src/Json/getRangeEnumeration.spec.ts
@@ -7,11 +7,11 @@ import {
 } from "./getRangeEnumeration";
 
 describe("isInvalidFormat", () => {
-  it.each([
+  it.only.each([
     ["", false],
     ["\r\n        ", false],
     ["\r\n        \r\n ", false],
-    ["\r\n    0..255 bytes    \r\n ", true],
+    ["ValidCase", false],
     ["\r\n    0..255    \r\n ", false],
     ["\r\n    1,2,3    \r\n ", false],
     ["\r\n    1    \r\n ", false],
@@ -24,7 +24,14 @@ describe("isInvalidFormat", () => {
     ["1..64 Bytes", true],
     ["0..255 Gigabyte", true],
     ["no valid case", true],
-    ["ValidCase", false],
+    ["\r\n    0..255 bytes    \r\n ", true],
+    ["AVAILABLE; UNAVAILABLE", true],
+    ["0..2^28-1", true],
+    ["0; 3.8..20.5", true],
+    ["<7 to >12.5", true],
+    ["8-Bits", true],
+    ["2 Instances", true],
+    ["1: normal\r\n\t\t\t\t2: remote\r\n\t\t\t\t3: local", true],
   ])("Should check if format is invalid: %p -> %p", (value, expected) =>
     expect(isInvalidFormat(value)).toStrictEqual(expected)
   );

--- a/src/Json/getRangeEnumeration.spec.ts
+++ b/src/Json/getRangeEnumeration.spec.ts
@@ -118,11 +118,9 @@ describe("getRangeEnumeration", () => {
     ["0..255 bytes", { invalidFormat: true, value: "0..255 bytes" }],
     ["1..64 Bytes", { invalidFormat: true, value: "1..64 Bytes" }],
     ["0..255 Gigabyte", { invalidFormat: true, value: "0..255 Gigabyte" }],
+    ["0..2^28-1", { invalidFormat: true, value: "0..2^28-1" }],
     ["no valid case", { invalidFormat: true, value: "no valid case" }],
-    [
-      "ValidCase",
-      { invalidFormat: false, value: "ValidCase", dataStruct: "enum" },
-    ],
+    ["8-Bits", { invalidFormat: false, value: "8-Bits", dataStruct: "enum" }],
   ])("Should return range enumeration object: %p -> %p", (value, expected) =>
     expect(getRangeEnumeration(value)).toStrictEqual(expected)
   );

--- a/src/Json/getRangeEnumeration.ts
+++ b/src/Json/getRangeEnumeration.ts
@@ -1,33 +1,64 @@
 // TODO: add description
 // TODO: Update when this issue is resolved https://github.com/OpenMobileAlliance/lwm2m-registry/issues/690
 // https://github.com/OpenMobileAlliance/lwm2m-registry/pull/685
+
 /**
+ * Return true if format is invalid, false if it is valid.
  *
- * @param rangeEnumeration
+ * allowed formats:
+ *  1- VALUE
+ *  2- VALUE..VALUE
+ *  3- VALUE, VALUE, VALUE
+ *
+ * @param element
+ * @returns
+ */
+export const isInvalidFormat = (element: string) =>
+  element.split(/[..]|,/g).some((element) => /\s/.test(element.trim()));
+
+export const isRangeFormat = (element: string) =>
+  element.split("..").length > 1;
+
+const isSingleEnum = (element: string) =>
+  element.split(/[..]|,|' '/g).length === 1;
+
+const isListEnum = (element: string) => element.split(",").length > 1;
+
+const isEmptyValue = (element: string) => element.trim().length === 0;
+
+/**
+ * Create an object after analyze range enumeration composition
+ * @param value
  * @returns
  */
 export const getRangeEnumeration = (
-  rangeEnumeration: string
-): [...(number | null)[]] | null => {
-  //TODO: define if null or undefine
-  if (rangeEnumeration.length === 0) return null; // empty string case
+  value: string
+): {
+  invalidFormat: boolean;
+  value: Number | string | Number[] | String[] | null;
+  dataStruct?: "enum" | "range";
+} => {
+  if (isInvalidFormat(value)) return { invalidFormat: true, value: value };
 
-  if (rangeEnumeration.includes("..")) {
-    const minAndMax = rangeEnumeration.split("..");
+  if (isEmptyValue(value)) return { invalidFormat: false, value: null };
 
-    const minimum = minAndMax[0]
-      ? Number(minAndMax[0].replace(/\D/g, ""))
-      : null;
-    const maximum = minAndMax[1]
-      ? Number(minAndMax[1].replace(/\D/g, ""))
-      : null;
-    return [minimum, maximum];
+  if (isSingleEnum(value)) {
+    const enumValue = isNaN(+value) ? value : +value;
+    return { invalidFormat: false, value: enumValue, dataStruct: "enum" };
   }
 
-  if (rangeEnumeration.split(",").length > 1)
-    return rangeEnumeration
-      .split(",")
-      .map((element: string) => Number(element));
+  if (isRangeFormat(value)) {
+    const [min, max] = value.split("..");
+    return { invalidFormat: false, value: [+min, +max], dataStruct: "range" };
+  }
 
-  return null; // no valid case
+  if (isListEnum(value)) {
+    const isNumberList = value.split(",").some((element) => !isNaN(+element));
+    const enumList = isNumberList
+      ? value.split(",").map((element) => +element)
+      : value.split(",");
+    return { invalidFormat: false, value: enumList, dataStruct: "enum" };
+  }
+
+  return { invalidFormat: true, value: value };
 };

--- a/src/Json/getRangeEnumeration.ts
+++ b/src/Json/getRangeEnumeration.ts
@@ -75,6 +75,9 @@ export const getRangeEnumeration = (
 
   if (isRangeFormat(value)) {
     const [min, max] = value.split("..");
+    if (isNaN(+min) || isNaN(+max))
+      return { invalidFormat: true, value: value };
+
     return { invalidFormat: false, value: [+min, +max], dataStruct: "range" };
   }
 

--- a/src/Json/getRangeEnumeration.ts
+++ b/src/Json/getRangeEnumeration.ts
@@ -1,7 +1,3 @@
-// TODO: add description
-// TODO: Update when this issue is resolved https://github.com/OpenMobileAlliance/lwm2m-registry/issues/690
-// https://github.com/OpenMobileAlliance/lwm2m-registry/pull/685
-
 /**
  * Return true if format is invalid, false if it is valid.
  *
@@ -53,7 +49,8 @@ export const isListEnum = (element: string) => element.split(",").length > 1;
 const isEmptyValue = (element: string) => element.trim().length === 0;
 
 /**
- * Create an object after analyze range enumeration composition
+ * Create an object after analyze range enumeration composition.
+ * RangeEnumeratioan format definition: http://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/OMA-TS-LightweightM2M_Core-V1_1_1-20190617-A.pdf pag 110
  * @param value
  * @returns
  */

--- a/src/Json/getRangeEnumeration.ts
+++ b/src/Json/getRangeEnumeration.ts
@@ -16,14 +16,40 @@
 export const isInvalidFormat = (element: string) =>
   element.split(/[..]|,/g).some((element) => /\s/.test(element.trim()));
 
+/**
+ * Check if format is followed
+ * Format:
+ *  VALUE..VALUE
+ * @param element
+ * @returns
+ */
 export const isRangeFormat = (element: string) =>
-  element.split("..").length > 1;
+  element.length >= 4 && element.split("..").length === 2;
 
-const isSingleEnum = (element: string) =>
+/**
+ * Check if format is followed
+ * Format:
+ *  VALUE
+ * @param element
+ * @returns
+ */
+export const isSingleEnum = (element: string) =>
   element.split(/[..]|,|' '/g).length === 1;
 
-const isListEnum = (element: string) => element.split(",").length > 1;
+/**
+ * Check if format is followed
+ * Format:
+ *  VALUE, VALUE, VALUE
+ * @param element
+ * @returns
+ */
+export const isListEnum = (element: string) => element.split(",").length > 1;
 
+/**
+ * Check if value is an empty string
+ * @param element
+ * @returns
+ */
 const isEmptyValue = (element: string) => element.trim().length === 0;
 
 /**

--- a/src/Json/parseResource.spec.ts
+++ b/src/Json/parseResource.spec.ts
@@ -11,7 +11,7 @@ describe("parseResource", () => {
         units: ["s"],
       },
       {
-        rangeEnumeration: [1, 65534],
+        rangeEnumeration: "1..65534",
         mandatoryStatus: "Mandatory",
         multipleInstances: "Multiple",
         type: "Integer",
@@ -27,7 +27,7 @@ describe("parseResource", () => {
         units: [""],
       },
       {
-        rangeEnumeration: [1, 655, 34],
+        rangeEnumeration: "1,655,34",
         mandatoryStatus: "Optional",
         multipleInstances: "Single",
         type: "String",
@@ -43,7 +43,7 @@ describe("parseResource", () => {
         units: [""],
       },
       {
-        rangeEnumeration: null,
+        rangeEnumeration: "",
         mandatoryStatus: "Optional",
         multipleInstances: "Multiple",
         type: "String",

--- a/src/Json/parseResource.ts
+++ b/src/Json/parseResource.ts
@@ -1,5 +1,4 @@
 import { dataCleaning } from "./../utils/dataCleaning";
-import { getRangeEnumeration } from "./getRangeEnumeration";
 
 /**
  * Pick properties from element to generate the typebox definition
@@ -12,7 +11,7 @@ export const parseResource = (
   description: string;
   mandatoryStatus: string;
   multipleInstances: string;
-  rangeEnumeration: [...(number | null)[]] | null;
+  rangeEnumeration: string;
   id: string;
   units: string;
 } => {
@@ -21,7 +20,7 @@ export const parseResource = (
   const description = dataCleaning(element.Description[0]);
   const mandatoryStatus = element.Mandatory[0];
   const multipleInstances = element.MultipleInstances[0];
-  const rangeEnumeration = getRangeEnumeration(element.RangeEnumeration[0]);
+  const rangeEnumeration = element.RangeEnumeration[0];
   const id = element.ATTR.ID;
   const units = element.Units[0];
   return {

--- a/src/utils/validateWithJsonSchema.ts
+++ b/src/utils/validateWithJsonSchema.ts
@@ -11,7 +11,6 @@ export const validateWithJSONSchema = <T extends TSchema>(
   const ajv = new Ajv();
   // see @https://github.com/sinclairzx81/typebox/issues/51
   ajv.addKeyword("units");
-  ajv.addKeyword("enumeration");
   const v = ajv.compile(schema);
   return (value: unknown) => {
     const valid = v(value);


### PR DESCRIPTION
Some values coming from [LwM2M registry](https://github.com/OpenMobileAlliance/lwm2m-registry) are not following the standard for the RangeEnumeration value, which is defined [here, pag 110](http://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/OMA-TS-LightweightM2M_Core-V1_1_1-20190617-A.pdf) . 

After an evaluation ([analyze-range-enumeration](https://github.com/MLopezJ/analyze-range-enumeration)), the decision of ignore RangeEnumeration values for the type definition when it does not follow the standard was taken. 

Custom type definition and test cases were added for the expected formats:

1. -> "VALUE..VALUE"
2. -> "VALUE, VALUE, VALUE"
3. -> "VALUE"
